### PR TITLE
Add argument for recursively scanning font directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ options:
   --additional-fonts ADDITIONAL_FONTS [ADDITIONAL_FONTS ...]
                         May be a directory containing font files or a single font file. You can specify more than one
                         additional-fonts.
+  --font-root FONT_ROOT [FONT_ROOT ...]
+                        Path to font directory, which will be recursively searched for fonts.
   --exclude-system-fonts
                         If specified, FontCollector won't use the system font to find the font used by an .ass file.
   --collect-draw-fonts

--- a/README.md
+++ b/README.md
@@ -21,20 +21,21 @@ options:
   --input [INPUT ...], -i [INPUT ...]
                         Subtitles file. Must be an ASS file/directory. You can specify more than one .ass file/path.
                         If no argument is specified, it will take all the font in the current path.
-  -mkv MKV              
+  -mkv MKV
                         Video where the fonts will be merge. Must be a Matroska file.
   --output OUTPUT, -o OUTPUT
                         Destination path of the font. If -o and -mkv aren't specified, it will be the current path.
   -mkvpropedit MKVPROPEDIT
                         Path to mkvpropedit.exe if not in variable environments. If -mkv is not specified, it will do
                         nothing.
-  --delete-fonts, -d    
+  --delete-fonts, -d
                         If -d is specified, it will delete the font attached to the mkv before merging the new needed
                         font. If -mkv is not specified, it will do nothing.
-  --additional-fonts ADDITIONAL_FONTS [ADDITIONAL_FONTS ...]
+  --additional-fonts ADDITIONAL_FONTS [ADDITIONAL_FONTS ...], -add-fonts ADDITIONAL_FONTS [ADDITIONAL_FONTS ...]
                         May be a directory containing font files or a single font file. You can specify more than one
                         additional-fonts.
-  --font-root FONT_ROOT [FONT_ROOT ...]
+                        If it is a directory, it won't search recursively for fonts
+  --additional-fonts-recursive ADDITIONAL_FONTS_RECURSIVE [ADDITIONAL_FONTS_RECURSIVE ...], -add-fonts-rec ADDITIONAL_FONTS_RECURSIVE [ADDITIONAL_FONTS_RECURSIVE ...]
                         Path to font directory, which will be recursively searched for fonts.
   --exclude-system-fonts
                         If specified, FontCollector won't use the system font to find the font used by an .ass file.

--- a/font_collector/__main__.py
+++ b/font_collector/__main__.py
@@ -20,12 +20,12 @@ def main():
         mkv_path,
         delete_fonts,
         additional_fonts,
-        font_root,
+        additional_fonts_recursive,
         use_system_font,
         collect_draw_fonts
     ) = parse_arguments()
     font_results: List[FontResult] = []
-    font_collection = FontLoader(additional_fonts, use_system_font, font_root).fonts
+    font_collection = FontLoader(additional_fonts, use_system_font, additional_fonts_recursive).fonts
 
     for ass_path in ass_files_path:
         subtitle = AssDocument.from_file(ass_path)

--- a/font_collector/__main__.py
+++ b/font_collector/__main__.py
@@ -20,11 +20,12 @@ def main():
         mkv_path,
         delete_fonts,
         additional_fonts,
+        font_root,
         use_system_font,
         collect_draw_fonts
     ) = parse_arguments()
     font_results: List[FontResult] = []
-    font_collection = FontLoader(additional_fonts, use_system_font).fonts
+    font_collection = FontLoader(additional_fonts, use_system_font, font_root).fonts
 
     for ass_path in ass_files_path:
         subtitle = AssDocument.from_file(ass_path)

--- a/font_collector/font.py
+++ b/font_collector/font.py
@@ -17,7 +17,7 @@ from freetype import (
     FT_New_Memory_Face,
     FT_Set_Charmap,
 )
-from typing import Any, Dict, List, Sequence, Set, Tuple
+from typing import Any, Dict, List, Sequence, Set, Tuple, Union
 
 _logger = logging.getLogger(__name__)
 
@@ -52,10 +52,10 @@ class Font:
         self.named_instance_coordinates = named_instance_coordinates
 
     @classmethod
-    def from_font_path(cls, font_path: str) -> List["Font"]:
+    def from_font_path(cls, font_path: Union[str, os.PathLike[str]]) -> List["Font"]:
         """
         Parameters:
-            font_path (str): Font path. The font can be a .ttf, .otf or .ttc
+            font_path (str | PathLike[str]): Font path. The font can be a .ttf, .otf or .ttc
         Returns:
             An Font object that represent the file at the font_path
         """

--- a/font_collector/font_loader.py
+++ b/font_collector/font_loader.py
@@ -19,9 +19,10 @@ class FontLoader:
     additional_fonts: Set[Font]
 
     def __init__(
-        self, additional_fonts_path: Iterable[Path] = [],
-            use_system_font: bool = True,
-            font_root_path: Iterable[Path] = []
+        self,
+        additional_fonts_path: Iterable[Path] = [],
+        use_system_font: bool = True,
+        additional_fonts_path_recursive: Iterable[Path] = []
     ):
 
         if use_system_font:
@@ -29,7 +30,7 @@ class FontLoader:
         else:
             self.system_fonts = set()
 
-        self.additional_fonts = FontLoader.load_additional_fonts(font_root_path, scan_subdirs=True)
+        self.additional_fonts = FontLoader.load_additional_fonts(additional_fonts_path_recursive, scan_subdirs=True)
         self.additional_fonts.update(FontLoader.load_additional_fonts(additional_fonts_path, scan_subdirs=False))
 
     @property
@@ -63,7 +64,7 @@ class FontLoader:
     def load_font_cache_file(cache_file: Path) -> Set[Font]:
         if not os.path.isfile(cache_file):
             raise FileNotFoundError(f'The file "{cache_file}" does not exist')
-        
+
         with open(cache_file, "rb") as file:
             file_content = pickle.load(file)
 
@@ -77,7 +78,7 @@ class FontLoader:
             if font_collector_cache_version != __version__:
                 os.remove(cache_file)
                 return set()
-            
+
             return cached_fonts
         raise FileExistsError(f'The file "{cache_file}" contain invalid data')
 

--- a/font_collector/font_loader.py
+++ b/font_collector/font_loader.py
@@ -135,6 +135,9 @@ class FontLoader:
 
     @staticmethod
     def load_additional_fonts(additional_fonts_path: Iterable[Path], scan_subdirs=False) -> Set[Font]:
+        def is_file_font(file_name: Path):
+            return file_name.suffix.lstrip(".").strip().lower() in ["ttf", "otf", "ttc", "otc"]
+
         additional_fonts: Set[Font] = set()
 
         for font_path in additional_fonts_path:
@@ -144,14 +147,15 @@ class FontLoader:
                 if scan_subdirs:
                     for root, dirs, files in os.walk(font_path):
                         for name in files:
-                            file = Path(os.path.join(root, name))
-                            if file.suffix.lstrip(".").strip().lower() in ["ttf", "otf", "ttc", "otc"]:
-                                additional_fonts.update(Font.from_font_path(file))
+                            file_path = os.path.join(root, name)
+                            if is_file_font(Path(file_path)):
+                                additional_fonts.update(Font.from_font_path(file_path))
 
                 else:
                     for file in os.listdir(font_path):
-                        if Path(file).suffix.lstrip(".").strip().lower() in ["ttf", "otf", "ttc", "otc"]:
-                            additional_fonts.update(Font.from_font_path(os.path.join(font_path, file)))
+                        file_path = os.path.join(font_path, file)
+                        if is_file_font(Path(file_path)):
+                            additional_fonts.update(Font.from_font_path(file_path))
             else:
                 raise FileNotFoundError(f"The file {font_path} is not reachable")
         return additional_fonts

--- a/font_collector/parse_arguments.py
+++ b/font_collector/parse_arguments.py
@@ -37,6 +37,7 @@ def parse_arguments() -> Tuple[
     Union[Path, None],
     bool,
     Set[Path],
+    Set[Path],
     bool,
     bool
 ]:
@@ -97,6 +98,14 @@ def parse_arguments() -> Tuple[
     """,
     )
     parser.add_argument(
+        "--font-root",
+        nargs="+",
+        type=Path,
+        help="""
+    Path to font directory, which will be recursively searched for fonts.
+    """,
+    )
+    parser.add_argument(
         "--exclude-system-fonts",
         action="store_false",
         help="""
@@ -130,6 +139,11 @@ def parse_arguments() -> Tuple[
     else:
         additional_fonts = set()
 
+    if args.font_root is not None:
+        font_root = args.font_root
+    else:
+        font_root = set()
+
     use_system_fonts = args.exclude_system_fonts
     collect_draw_fonts = args.collect_draw_fonts
 
@@ -139,6 +153,7 @@ def parse_arguments() -> Tuple[
         mkv_path,
         delete_fonts,
         additional_fonts,
+        font_root,
         use_system_fonts,
         collect_draw_fonts
     )

--- a/font_collector/parse_arguments.py
+++ b/font_collector/parse_arguments.py
@@ -91,10 +91,12 @@ def parse_arguments() -> Tuple[
     )
     parser.add_argument(
         "--additional-fonts",
+        "-add-fonts",
         nargs="+",
         type=Path,
         help="""
     May be a directory containing font files or a single font file. You can specify more than one additional-fonts.
+    If it is a directory, it won't search recursively for fonts
     """,
     )
     parser.add_argument(

--- a/font_collector/parse_arguments.py
+++ b/font_collector/parse_arguments.py
@@ -98,7 +98,8 @@ def parse_arguments() -> Tuple[
     """,
     )
     parser.add_argument(
-        "--font-root",
+        "--additional-fonts-recursive",
+        "-add-fonts-rec",
         nargs="+",
         type=Path,
         help="""
@@ -139,10 +140,10 @@ def parse_arguments() -> Tuple[
     else:
         additional_fonts = set()
 
-    if args.font_root is not None:
-        font_root = args.font_root
+    if args.additional_fonts_recursive is not None:
+        additional_fonts_recursive = args.additional_fonts_recursive
     else:
-        font_root = set()
+        additional_fonts_recursive = set()
 
     use_system_fonts = args.exclude_system_fonts
     collect_draw_fonts = args.collect_draw_fonts
@@ -153,7 +154,7 @@ def parse_arguments() -> Tuple[
         mkv_path,
         delete_fonts,
         additional_fonts,
-        font_root,
+        additional_fonts_recursive,
         use_system_fonts,
         collect_draw_fonts
     )

--- a/tests/test_font_loader.py
+++ b/tests/test_font_loader.py
@@ -1,0 +1,53 @@
+import os
+from font_collector import FontLoader
+from pathlib import Path
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+
+def test_load_additional_fonts():
+    font_directory = os.path.join(dir_path, "fonts")
+
+    fonts_result = FontLoader.load_additional_fonts([Path(font_directory)])
+    result = list(set([font.filename for font in fonts_result]))
+    expected_result = [
+        os.path.join(font_directory, "Asap-VariableFont_wdth,wght.ttf"),
+        os.path.join(font_directory, "Cabin VF Beta Regular.ttf"),
+        os.path.join(font_directory, "font_cmap_encoding_0.ttf"),
+        os.path.join(font_directory, "font_cmap_encoding_1.ttf"),
+        os.path.join(font_directory, "font_cmap_encoding_2.TTF"),
+        os.path.join(font_directory, "font_mac.TTF"),
+        os.path.join(font_directory, "font_without axis_value.ttf")
+    ]
+
+    assert sorted(result) == sorted(expected_result)
+
+
+    fonts_result = FontLoader.load_additional_fonts([Path(font_directory)], scan_subdirs=True)
+    result = list(set([font.filename for font in fonts_result]))
+    expected_result.extend([
+        os.path.join(font_directory, "Raleway", "Raleway-Black.ttf"),
+        os.path.join(font_directory, "Raleway", "Raleway-Bold.ttf"),
+        os.path.join(font_directory, "Raleway", "Raleway-BoldItalic.ttf"),
+        os.path.join(font_directory, "Raleway", "Raleway-ExtraBold.ttf"),
+        os.path.join(font_directory, "Raleway", "Raleway-ExtraLight.ttf"),
+        os.path.join(font_directory, "Raleway", "Raleway-Italic.ttf"),
+        os.path.join(font_directory, "Raleway", "Raleway-Light.ttf"),
+        os.path.join(font_directory, "Raleway", "Raleway-Medium.ttf"),
+        os.path.join(font_directory, "Raleway", "Raleway-Regular.ttf"),
+        os.path.join(font_directory, "Raleway", "Raleway-SemiBold.ttf"),
+        os.path.join(font_directory, "Raleway", "Raleway-Thin.ttf"),
+        os.path.join(font_directory, "Raleway", "generated_fonts", "Raleway-Black.ttf - generated.ttf"),
+        os.path.join(font_directory, "Raleway", "generated_fonts", "Raleway-Bold.ttf - generated.ttf"),
+        os.path.join(font_directory, "Raleway", "generated_fonts", "Raleway-BoldItalic.ttf - generated.ttf"),
+        os.path.join(font_directory, "Raleway", "generated_fonts", "Raleway-ExtraBold.ttf - generated.ttf"),
+        os.path.join(font_directory, "Raleway", "generated_fonts", "Raleway-ExtraLight.ttf - generated.ttf"),
+        os.path.join(font_directory, "Raleway", "generated_fonts", "Raleway-Italic.ttf - generated.ttf"),
+        os.path.join(font_directory, "Raleway", "generated_fonts", "Raleway-Light.ttf - generated.ttf"),
+        os.path.join(font_directory, "Raleway", "generated_fonts", "Raleway-Medium.ttf - generated.ttf"),
+        os.path.join(font_directory, "Raleway", "generated_fonts", "Raleway-Regular.ttf - generated.ttf"),
+        os.path.join(font_directory, "Raleway", "generated_fonts", "Raleway-SemiBold.ttf - generated.ttf"),
+        os.path.join(font_directory, "Raleway", "generated_fonts", "Raleway-Thin.ttf - generated.ttf"),
+    ])
+
+    assert sorted(result) == sorted(expected_result)


### PR DESCRIPTION
Recursive font scanning significantly improves the workflow when all fonts are not stored in a flat directory structure.

Related: #29