### PR TITLE
Update run_test.yml

### DIFF
--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -24,10 +24,27 @@ jobs:
     - name: Install Python requirements
       run: pip install --upgrade --upgrade-strategy eager .
 
+    - name: Install platform-specific requirements (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt update
+        sudo apt install mkvtoolnix
+
+    - name: Install platform-specific requirements (macOS)
+      if: matrix.os == 'macos-latest'
+      run: brew install mkvtoolnix
+
+    - name: Install platform-specific requirements (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        choco install mkvtoolnix
+        echo '##[set-output name=PATH;]${env:PATH};${env:ChocolateyInstall}\bin'
+
     - name: Install pytest
       run: |
         pip install pytest
 
     - name: Run tests
       run: |
+        mkvpropedit -h
         pytest


### PR DESCRIPTION
Windows Environment Variables:

On Windows, set the output for PATH in the Install platform-specific requirements (Windows) step. This output is then used to update the PATH for subsequent steps.

Use Persisted Environment in Subsequent Steps:

When setting the PATH in the Windows step, it's now appended to the existing PATH. This makes the changes persist across steps, allowing you to use mkvpropedit in the Run tests step.