### PR TITLE
[font_collection] Don't ignore the reload_system_font flags

### DIFF
--- a/font_collector/font/font_collection.py
+++ b/font_collector/font/font_collection.py
@@ -43,6 +43,7 @@ class FontCollection:
         self.reload_system_font = reload_system_font
         self.use_generated_fonts = use_generated_fonts
         self.additional_fonts = additional_fonts
+        self.__system_fonts: Optional[List[FontFile]] = None
 
 
     def __iter__(self) -> Generator[FontFile, None, None]:
@@ -56,7 +57,7 @@ class FontCollection:
             if self.reload_system_font:
                 return FontLoader.load_system_fonts()
 
-            if not hasattr(self, '__system_fonts'):
+            if self.__system_fonts is None:
                 self.__system_fonts = FontLoader.load_system_fonts()
             return self.__system_fonts
         return []


### PR DESCRIPTION
Since __system_fonts is a private attribute, hasattr(self, '__system_fonts') doesn't actually check if the fontcollection has the __system_fonts attribute.

It would work if it would be hasattr(self, '_FontCollection__system_fonts'), but that's a bit hacky, so let's declare self.__system_fonts in the __init__