### PR TITLE
Update ass dependency to allow v1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "ass < 1",
+    "ass>=1.0.0, < 2",
     "ass-tag-analyzer < 1",
     "fontTools>=4.55.0, < 5",
     "freetype-py>2, < 3",


### PR DESCRIPTION
Updates the `ass` dependency constraint from `<1` to `>=1.0.0, <2`.

The ASS v1.0.0 release contained no code changes, only dropped support for Python <3.8. Tests pass as expected.